### PR TITLE
DMOH-43: Added methods to get a Service by its URI or Vesta ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `gent/services-opening-hours` package.
 
+## [Unreleased]
+
+### Added
+
+* DMOH-43: Added method to get a Service by its URI.
+
 ## [0.1.0]
 
 Initial release providing API to get Services & Channels + access the opening

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Notable changes to `gent/services-opening-hours` package.
 ### Added
 
 * DMOH-43: Added method to get a Service by its URI.
+* DMOH-43: Added method to get a Service by its Vesta ID.
 
 ## [0.1.0]
 

--- a/examples/103-Service-GetById.php
+++ b/examples/103-Service-GetById.php
@@ -3,13 +3,13 @@
 /**
  * StadGent\Services\OpeningHours Examples.
  *
- * Example how load a single Service by its id.
+ * Example how to load a single Service by its id.
  */
 
 require_once __DIR__ . '/bootstrap.php';
 
 
-example_print_header('Example how load a single Service by its id.');
+example_print_header('Example how to load a single Service by its id.');
 
 
 

--- a/examples/104-Service-GetByOpenDataUri.php
+++ b/examples/104-Service-GetByOpenDataUri.php
@@ -3,13 +3,13 @@
 /**
  * StadGent\Services\OpeningHours Examples.
  *
- * Example how load a single Service by its id.
+ * Example how to get a single service by its open data URI.
  */
 
 require_once __DIR__ . '/bootstrap.php';
 
 
-example_print_header('Example how load a single Service by its id.');
+example_print_header('Example how to get a single service by its open data URI.');
 
 
 
@@ -26,16 +26,17 @@ $client = new \StadGent\Services\OpeningHours\Client\Client($guzzleClient, $conf
 example_print_step('Get the ServiceService.');
 $service = \StadGent\Services\OpeningHours\Service::create($client);
 
-example_print_step('Search Services GetById');
+example_print_step('Search Services GetByOpenDataUri');
 example_print();
 
 try {
-    $serviceItem = $service->getById($service_id);
+    $serviceItem = $service->getByOpenDataUri($service_uri);
     example_sprintf(' Id       : %d', $serviceItem->getId());
+    example_sprintf(' URI      : %s', $serviceItem->getUri());
     example_sprintf(' Label    : %s', $serviceItem->getLabel());
     example_sprintf(' Is Draft : %d', (int) $serviceItem->isDraft());
 } catch (\StadGent\Services\OpeningHours\Exception\ServiceNotFoundException $e) {
-    example_sprintf(' ! No Service found for id : %d', $service_id);
+    example_sprintf(' ! No Service found for URI : %s', $service_uri);
 } catch (\Exception $e) {
     example_sprintf(' ! Error : %s', $e->getMessage());
 }

--- a/examples/105-Service-GetByVestaId.php
+++ b/examples/105-Service-GetByVestaId.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * StadGent\Services\OpeningHours Examples.
+ *
+ * Example how to get a single service by its Vesta ID.
+ */
+
+require_once __DIR__ . '/bootstrap.php';
+
+
+example_print_header('Example how to get a single service by its Vesta ID.');
+
+
+
+
+example_print_step('Create the API client configuration.');
+$configuration = new \StadGent\Services\OpeningHours\Configuration\Configuration($apiEndpoint);
+
+example_print_step('Create the Guzzle client.');
+$guzzleClient = new \GuzzleHttp\Client(['base_uri' => $configuration->getUri()]);
+
+example_print_step('Create the HTTP client.');
+$client = new \StadGent\Services\OpeningHours\Client\Client($guzzleClient, $configuration);
+
+example_print_step('Get the ServiceService.');
+$service = \StadGent\Services\OpeningHours\Service::create($client);
+
+example_print_step('Search Services GetByOpenDataUri');
+example_print();
+
+try {
+    $serviceItem = $service->getByVestaId($service_vesta_id);
+    example_sprintf(' Id        : %d', $serviceItem->getId());
+    example_sprintf(' URI       : %s', $serviceItem->getUri());
+    example_sprintf(' Label     : %s', $serviceItem->getLabel());
+    example_sprintf(' Is Draft  : %d', (int) $serviceItem->isDraft());
+    example_sprintf(' Source    : %s', $serviceItem->getSource()->getName());
+    example_sprintf(' Source ID : %s', $serviceItem->getSource()->getId());
+} catch (\StadGent\Services\OpeningHours\Exception\ServiceNotFoundException $e) {
+    example_sprintf(' ! No Service found for Vesta ID : %s', $service_vesta_id);
+} catch (\Exception $e) {
+    example_sprintf(' ! Error : %s', $e->getMessage());
+}
+
+
+
+
+example_print_footer();

--- a/examples/config.example.php
+++ b/examples/config.example.php
@@ -20,6 +20,9 @@ $service_id = '';
 // Service to load by its uri.
 $service_uri = '';
 
+// Service to load by its Vesta ID.
+$service_vesta_id = '';
+
 
 
 

--- a/examples/config.example.php
+++ b/examples/config.example.php
@@ -17,6 +17,9 @@ $service_label = '';
 // This id will also be used to lookup channels and opening hours.
 $service_id = '';
 
+// Service to load by its uri.
+$service_uri = '';
+
 
 
 

--- a/src/Handler/Service/GetByOpenDataUriHandler.php
+++ b/src/Handler/Service/GetByOpenDataUriHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace StadGent\Services\OpeningHours\Handler\Service;
+
+use StadGent\Services\OpeningHours\Handler\HandlerAbstract;
+use StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest;
+use StadGent\Services\OpeningHours\Response\ServiceResponse;
+use StadGent\Services\OpeningHours\Value\Service;
+use Psr\Http\Message as Psr;
+
+/**
+ * Handler to Get a Service by its open data URI.
+ *
+ * @package StadGent\Services\OpeningHours\Handler\Service
+ */
+class GetByOpenDataUriHandler extends HandlerAbstract
+{
+    /**
+     * @inheritDoc
+     */
+    public function handles()
+    {
+        return [
+            GetByOpenDataUriRequest::class,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function toResponse(Psr\ResponseInterface $response)
+    {
+        $all = $this->getBodyData($response);
+        $data = reset($all);
+        $service = Service::fromArray($data);
+        return new ServiceResponse($service);
+    }
+}

--- a/src/Request/Service/GetByOpenDataUriRequest.php
+++ b/src/Request/Service/GetByOpenDataUriRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace StadGent\Services\OpeningHours\Request\Service;
+
+use StadGent\Services\OpeningHours\Request\RequestAbstract;
+use StadGent\Services\OpeningHours\Uri\Service\GetByOpenDataUriUri;
+
+/**
+ * Request to get a Service by its open data URI.
+ *
+ * @package StadGent\Services\OpeningHours\Request\Service
+ */
+class GetByOpenDataUriRequest extends RequestAbstract
+{
+    /**
+     * Get a single Service by its open data URI.
+     *
+     * @param string $openDataUri
+     *   The Service open data URI.
+     */
+    public function __construct($openDataUri)
+    {
+        $uri = new GetByOpenDataUriUri($openDataUri);
+        parent::__construct($uri);
+    }
+}

--- a/src/Service.php
+++ b/src/Service.php
@@ -6,6 +6,7 @@ use StadGent\Services\OpeningHours\Client\ClientInterface;
 use Psr\SimpleCache\CacheInterface;
 use StadGent\Services\OpeningHours\Handler\Service\GetAllHandler;
 use StadGent\Services\OpeningHours\Handler\Service\GetByIdHandler;
+use StadGent\Services\OpeningHours\Handler\Service\GetByOpenDataUriHandler;
 use StadGent\Services\OpeningHours\Handler\Service\SearchByLabelHandler;
 use StadGent\Services\OpeningHours\Service\Service\ServiceService;
 
@@ -32,6 +33,7 @@ class Service
         $client
             ->addHandler(new GetAllHandler())
             ->addHandler(new GetByIdHandler())
+            ->addHandler(new GetByOpenDataUriHandler())
             ->addHandler(new SearchByLabelHandler())
         ;
 

--- a/src/Service/Service/ServiceService.php
+++ b/src/Service/Service/ServiceService.php
@@ -161,6 +161,25 @@ class ServiceService extends ServiceAbstract
     }
 
     /**
+     * Get a service by its Vesta Id.
+     *
+     * @param string $vestaId
+     *
+     * @return \StadGent\Services\OpeningHours\Value\Service
+     *
+     * @throws \Exception
+     * @throws \GuzzleHttp\Exception\RequestException
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws \StadGent\Services\OpeningHours\Exception\NotFoundException
+     * @throws \StadGent\Services\OpeningHours\Exception\ServiceNotFoundException
+     */
+    public function getByVestaId($vestaId)
+    {
+        $uri = sprintf('https://stad.gent/id/agents/%s', $vestaId);
+        return $this->getByOpenDataUri($uri);
+    }
+
+    /**
      * Helper to create a cache key.
      *
      * @param array $parts

--- a/src/Service/Service/ServiceService.php
+++ b/src/Service/Service/ServiceService.php
@@ -5,6 +5,7 @@ namespace StadGent\Services\OpeningHours\Service\Service;
 use StadGent\Services\OpeningHours\Exception\ExceptionFactory;
 use StadGent\Services\OpeningHours\Request\Service\GetAllRequest;
 use StadGent\Services\OpeningHours\Request\Service\GetByIdRequest;
+use StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest;
 use StadGent\Services\OpeningHours\Request\Service\SearchByLabelRequest;
 use StadGent\Services\OpeningHours\Response\ServiceResponse;
 use StadGent\Services\OpeningHours\Response\ServicesResponse;
@@ -73,7 +74,6 @@ class ServiceService extends ServiceAbstract
         return $response->getServices();
     }
 
-
     /**
      * Get a single Service by its ID.
      *
@@ -104,6 +104,49 @@ class ServiceService extends ServiceAbstract
             // Get from service.
             $response = $this->send(
                 new GetByIdRequest($serviceId),
+                ServiceResponse::class
+            );
+        } catch (\Exception $e) {
+            ExceptionFactory::fromException($e);
+        }
+
+        /* @var $response \StadGent\Services\OpeningHours\Response\ServiceResponse */
+        $service = $response->getService();
+        $this->cacheSet($cacheKey, $service);
+
+        return $service;
+    }
+
+    /**
+     * Get a single Service by its open data uri.
+     *
+     * @param string $openDataUri
+     *   The Service open data uri.
+     *
+     * @return \StadGent\Services\OpeningHours\Value\Service
+     *
+     * @throws \Exception
+     * @throws \GuzzleHttp\Exception\RequestException
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws \StadGent\Services\OpeningHours\Exception\NotFoundException
+     * @throws \StadGent\Services\OpeningHours\Exception\ServiceNotFoundException
+     */
+    public function getByOpenDataUri($openDataUri)
+    {
+        $cacheKey = $this->createCacheKeyFromArray(
+            ['uri', $openDataUri]
+        );
+
+        // By default from cache.
+        $cached = $this->cacheGet($cacheKey);
+        if ($cached) {
+            return $cached;
+        }
+
+        try {
+            // Get from service.
+            $response = $this->send(
+                new GetByOpenDataUriRequest($openDataUri),
                 ServiceResponse::class
             );
         } catch (\Exception $e) {

--- a/src/Uri/Service/GetByOpenDataUriUri.php
+++ b/src/Uri/Service/GetByOpenDataUriUri.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace StadGent\Services\OpeningHours\Uri\Service;
+
+use StadGent\Services\OpeningHours\Uri\Uri;
+
+/**
+ * Uri to get a single service by its open data URI.
+ *
+ * @package StadGent\Services\OpeningHours\Uri\Channel
+ */
+class GetByOpenDataUriUri extends Uri
+{
+    /**
+     * Construct the URI.
+     *
+     * @param string $openDataUri
+     *   The Service open data URI.
+     */
+    public function __construct($openDataUri)
+    {
+        $uri = sprintf('services?uri=%s', $openDataUri);
+        parent::__construct($uri);
+    }
+}

--- a/tests/Handler/Service/GetByOpenDataUriHandlerTest.php
+++ b/tests/Handler/Service/GetByOpenDataUriHandlerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace StadGent\Services\Test\OpeningHours\Handler\Service;
+
+use StadGent\Services\OpeningHours\Handler\Service\GetByOpenDataUriHandler;
+use StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest;
+use StadGent\Services\OpeningHours\Response\ServiceResponse;
+use StadGent\Services\Test\OpeningHours\Handler\HandlerTestBase;
+
+/**
+ * Test the GetByIdHandler.
+ *
+ * @package StadGent\Services\Test\OpeningHours\Handler\Service
+ *
+ * @covers StadGent\Services\OpeningHours\Handler\Service\GetByOpenDataUriHandler
+ */
+class GetByOpenDataUriHandlerTest extends HandlerTestBase
+{
+    /**
+     * Test the handles method.
+     */
+    public function testHandles()
+    {
+        $handler = new GetByOpenDataUriHandler();
+        $this->assertEquals(
+            [GetByOpenDataUriRequest::class],
+            $handler->handles(),
+            'Handler only handles \StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest.'
+        );
+    }
+
+    /**
+     * Test the toResponse method with returned data.
+     */
+    public function testToResponseWithData()
+    {
+        $body = <<<EOT
+    [
+        {
+            "id": 1,
+            "uri": "http://dev.foo/FizzBuzz",
+            "label": "Fizz Buzz",
+            "description": "Fizz Buzz description",
+            "createdAt": "2017-05-18 15:04:49",
+            "updatedAt": "2017-11-17 12:01:13",
+            "sourceIdentifier": "",
+            "source": null,
+            "draft": 0,
+            "countChannels": 1
+        }
+    ]
+EOT;
+        $serviceResponse = $this->createResponseMock(200, $body);
+
+        $handler = new GetByOpenDataUriHandler();
+        $response = $handler->toResponse($serviceResponse);
+
+        $this->assertInstanceOf(
+            ServiceResponse::class,
+            $response,
+            'Response should be a \StadGent\Services\OpeningHours\Response\ServiceResponse object.'
+        );
+    }
+}

--- a/tests/Request/Service/GetByOpenDataUriRequestTest.php
+++ b/tests/Request/Service/GetByOpenDataUriRequestTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace StadGent\Services\Test\OpeningHours\Request\Service;
+
+use StadGent\Services\OpeningHours\Request\AcceptType;
+use StadGent\Services\OpeningHours\Request\MethodType;
+use PHPUnit\Framework\TestCase;
+use StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest;
+
+/**
+ * Test the GetByIdRequest object.
+ *
+ * @package StadGent\Services\Test\OpeningHours\Request\Service
+ *
+ * @covers \StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest
+ */
+class GetByOpenDataUriRequestTest extends TestCase
+{
+    /**
+     * Test if the method is GET.
+     */
+    public function testMethodIsGet()
+    {
+        $request = new GetByOpenDataUriRequest('http://foo.bar');
+        $this->assertEquals(MethodType::GET, $request->getMethod());
+    }
+
+    /**
+     * Test if the proper endpoint (URI) is set.
+     */
+    public function testEndpoint()
+    {
+        $request = new GetByOpenDataUriRequest('http://foo.bar');
+        $this->assertEquals('services?uri=http://foo.bar', $request->getRequestTarget());
+    }
+
+    /**
+     * Test if the proper headers are set.
+     */
+    public function testHeaders()
+    {
+        $request = new GetByOpenDataUriRequest('http://foo.bar');
+        $this->assertEquals(AcceptType::JSON, $request->getHeaderLine('Accept'));
+    }
+}

--- a/tests/Service/Service/ServiceServiceGetByOpenDataUriTest.php
+++ b/tests/Service/Service/ServiceServiceGetByOpenDataUriTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace StadGent\Services\Test\OpeningHours\Service\Service;
+
+use StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest;
+use StadGent\Services\OpeningHours\Response\ServiceResponse;
+use StadGent\Services\OpeningHours\Service\Service\ServiceService;
+use StadGent\Services\OpeningHours\Value\Service;
+use StadGent\Services\Test\OpeningHours\Service\ServiceTestBase;
+
+/**
+ * Tests for ServiceService::getById Method.
+ *
+ * @package StadGent\Services\Test\OpeningHours
+ *
+ * @covers \StadGent\Services\OpeningHours\Service\Service\ServiceService
+ */
+class ServiceServiceGetByOpenDataUriTest extends ServiceTestBase
+{
+    /**
+     * Test the getByOpenDataUri return object.
+     */
+    public function testGetByOpenDataUri()
+    {
+        $service = $this->createService();
+        $client = $this->createClientForService($service);
+
+        $serviceService = new ServiceService($client);
+        $responseService = $serviceService->getByOpenDataUri('http://foo.bar/123');
+        $this->assertSame($service, $responseService);
+    }
+
+    /**
+     * Test the getByOpenDataUri return object from cache.
+     */
+    public function testGetByOpenDataUriFromCache()
+    {
+        $service = $this->createService();
+        $client = $this->createClientForService($service);
+        $cache = $this->getFromCacheMock('OpeningHours:service:value:uri:http://foo.bar/123', $service);
+
+        $serviceService = new ServiceService($client);
+        $serviceService->setCacheService($cache);
+        $responseService = $serviceService->getByOpenDataUri('http://foo.bar/123');
+        $this->assertSame($service, $responseService);
+    }
+
+    /**
+     * Test the getByOpenDataUri setCache return object without cache.
+     */
+    public function testGetByIdSetCache()
+    {
+        $service = $this->createService();
+        $client = $this->createClientForService($service);
+        $cache = $this->getSetCacheMock('OpeningHours:service:value:uri:http://foo.bar/123', $service);
+
+        $serviceService = new ServiceService($client);
+        $serviceService->setCacheService($cache);
+        $serviceService->getByOpenDataUri('http://foo.bar/123');
+    }
+
+    /**
+     * Test the exception when the Open data URI does not exists.
+     *
+     * @expectedException \StadGent\Services\OpeningHours\Exception\ServiceNotFoundException
+     */
+    public function testServiceNotFoundException()
+    {
+        $client = $this->getClientWithServiceNotFoundExceptionMock();
+        $serviceService = new ServiceService($client);
+        $serviceService->getByOpenDataUri('http://foo.bar/123');
+    }
+
+    /**
+     * Helper to create a service.
+     *
+     * @return \StadGent\Services\OpeningHours\Value\Service
+     */
+    protected function createService()
+    {
+        return Service::fromArray(
+            [
+                'id' => 10,
+                'uri' => 'http://foo.bar/123',
+                'label' => 'FizzBazz label',
+                'createdAt' => '2345-11-05T12:45:00+01:00',
+                'updatedAt' => '2345-11-12T14:12:11+01:00',
+            ]
+        );
+    }
+
+    /**
+     * Helper to create a client that will return the given service.
+     *
+     * @param \StadGent\Services\OpeningHours\Value\Service $service
+     *
+     * @return \StadGent\Services\OpeningHours\Client\ClientInterface
+     */
+    protected function createClientForService(Service $service)
+    {
+        $response = new ServiceResponse($service);
+        $expectedRequest = GetByOpenDataUriRequest::class;
+        return $this->getClientMock($response, $expectedRequest);
+    }
+}

--- a/tests/Service/Service/ServiceServiceGetByVestaIdTest.php
+++ b/tests/Service/Service/ServiceServiceGetByVestaIdTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace StadGent\Services\Test\OpeningHours\Service\Service;
+
+use StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest;
+use StadGent\Services\OpeningHours\Response\ServiceResponse;
+use StadGent\Services\OpeningHours\Service\Service\ServiceService;
+use StadGent\Services\OpeningHours\Value\Service;
+use StadGent\Services\Test\OpeningHours\Service\ServiceTestBase;
+
+/**
+ * Tests for ServiceService::getById Method.
+ *
+ * @package StadGent\Services\Test\OpeningHours
+ *
+ * @covers \StadGent\Services\OpeningHours\Service\Service\ServiceService
+ */
+class ServiceServiceGetByVestaIdTest extends ServiceTestBase
+{
+    /**
+     * Test if the proper URI is created by checking what cache key is created.
+     */
+    public function testGetByVestaId()
+    {
+        $service = $this->createService();
+        $client = $this->createClientForService($service);
+        $cache = $this->getFromCacheMock('OpeningHours:service:value:uri:https://stad.gent/id/agents/123', $service);
+
+        $serviceService = new ServiceService($client);
+        $serviceService->setCacheService($cache);
+        $responseService = $serviceService->getByVestaId('123');
+        $this->assertSame($service, $responseService);
+    }
+
+    /**
+     * Helper to create a service.
+     *
+     * @return \StadGent\Services\OpeningHours\Value\Service
+     */
+    protected function createService()
+    {
+        return Service::fromArray(
+            [
+                'id' => 10,
+                'uri' => 'https://stad.gent/id/agents/123',
+                'label' => 'FizzBazz label',
+                'createdAt' => '2345-11-05T12:45:00+01:00',
+                'updatedAt' => '2345-11-12T14:12:11+01:00',
+            ]
+        );
+    }
+
+    /**
+     * Helper to create a client that will return the given service.
+     *
+     * @param \StadGent\Services\OpeningHours\Value\Service $service
+     *
+     * @return \StadGent\Services\OpeningHours\Client\ClientInterface
+     */
+    protected function createClientForService(Service $service)
+    {
+        $response = new ServiceResponse($service);
+        $expectedRequest = GetByOpenDataUriRequest::class;
+        return $this->getClientMock($response, $expectedRequest);
+    }
+}

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -7,6 +7,7 @@ use Psr\SimpleCache\CacheInterface;
 use StadGent\Services\OpeningHours\Client\ClientInterface;
 use StadGent\Services\OpeningHours\Handler\Service\GetAllHandler;
 use StadGent\Services\OpeningHours\Handler\Service\GetByIdHandler;
+use StadGent\Services\OpeningHours\Handler\Service\GetByOpenDataUriHandler;
 use StadGent\Services\OpeningHours\Handler\Service\SearchByLabelHandler;
 use StadGent\Services\OpeningHours\Service;
 use StadGent\Services\OpeningHours\Service\Service\ServiceService;
@@ -29,6 +30,7 @@ class ServiceTest extends TestCase
         $expectedHandlers = [
             GetAllHandler::class,
             GetByIdHandler::class,
+            GetByOpenDataUriHandler::class,
             SearchByLabelHandler::class,
         ];
 
@@ -67,8 +69,9 @@ class ServiceTest extends TestCase
         foreach ($invocations as $invocation) {
              /** @noinspection PhpUndefinedFieldInspection */
              $handler = get_class($invocation->parameters[0]);
-             $this->assertTrue(
-                 in_array($handler, $expectedHandlers, true),
+             $this->assertContains(
+                 $handler,
+                 $expectedHandlers,
                  sprintf('Handler "%s" is added by the factory.', $handler)
              );
         }
@@ -81,19 +84,13 @@ class ServiceTest extends TestCase
     {
         $collection = ServiceCollection::fromArray([]);
 
-        $client = $this
-            ->getMockBuilder(ClientInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(ClientInterface::class);
         $client
             ->expects($this->any())
             ->method('addHandler')
             ->will($this->returnValue($client));
 
-        $cache = $this
-            ->getMockBuilder(CacheInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $cache = $this->createMock(CacheInterface::class);
         $cache
             ->expects($this->once())
             ->method('get')

--- a/tests/Uri/Service/GetByOpenDataUriUriTest.php
+++ b/tests/Uri/Service/GetByOpenDataUriUriTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace StadGent\Services\Test\OpeningHours\Uri\Service;
+
+use PHPUnit\Framework\TestCase;
+use StadGent\Services\OpeningHours\Uri\Service\GetByOpenDataUriUri;
+
+/**
+ * Tests for GetByOpenDataUriUri.
+ *
+ * @package StadGent\Services\Test\OpeningHours
+ *
+ * @covers \StadGent\Services\OpeningHours\Uri\Service\GetByOpenDataUriUri
+ */
+class GetByOpenDataUriUriTest extends TestCase
+{
+    /**
+     * Test the URI constructor.
+     */
+    public function testConstruct()
+    {
+        $uri = 'https://stad.gent/id/agents/abcde1234567890';
+        $uriUri = new GetByOpenDataUriUri($uri);
+
+        $expected = 'services?uri=' . $uri;
+        $this->assertEquals($expected, $uriUri->getUri());
+    }
+}


### PR DESCRIPTION
Added missing functionality to get an OpeningHours service by its Open data URI or Vesta Id.

## Description

A service can be retrieved from the OpeningHours platform by its Open data URI.
If a service has Vesta as source, its Vesta ID is in that URI.

Added support to retrieve a service by it's Vesta ID By adding a method to retrieve the Service by its URI and by adding a wrapping method that creates that URI from the Vesta ID.

## Motivation and Context

Reverse lookup of a service by its Vesta ID.

## How Has This Been Tested?

[x] PHPUnit tests.
[x] Example code.

## Types of changes

- [x] New feature (non-breaking change which adds functionality).

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
