### PR TITLE
Added PHP 7.2 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.2
   - 7.1
   - 7.0
   - 5.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `gent/services-opening-hours` package.
 
+## [Unreleased]
+
+### Added
+
+* Added PHP 7.2 support.
+
 ## [0.2.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.*",
+        "phpunit/phpunit": "5.7.* || ^6",
         "squizlabs/php_codesniffer": "^2.3",
         "brainmaestro/composer-git-hooks": "^2.4",
         "mihaeu/html-formatter": "*"

--- a/tests/ChannelOpeningHoursHtmlTest.php
+++ b/tests/ChannelOpeningHoursHtmlTest.php
@@ -15,6 +15,8 @@ use StadGent\Services\OpeningHours\Value\ChannelCollection;
  * Tests the ChannelOpeningHoursHtmlServiceFactory.
  *
  * @package StadGent\Services\Test\OpeningHours
+ *
+ * @covers \StadGent\Services\OpeningHours\ChannelOpeningHoursHtml
  */
 class ChannelOpeningHoursHtmlTest extends TestCase
 {
@@ -31,10 +33,7 @@ class ChannelOpeningHoursHtmlTest extends TestCase
         ];
 
         // Create the client so we can spy on the factory method.
-        $client = $this
-            ->getMockBuilder(ClientInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(ClientInterface::class);
 
         // Inject a spy so we can validate the injected handlers.
         $spy = $this->any();
@@ -63,12 +62,16 @@ class ChannelOpeningHoursHtmlTest extends TestCase
         // Validate the added handlers.
         $invocations = $spy->getInvocations();
         foreach ($invocations as $invocation) {
-             /** @noinspection PhpUndefinedFieldInspection */
-             $handler = get_class($invocation->parameters[0]);
-             $this->assertTrue(
-                 in_array($handler, $expectedHandlers, true),
-                 sprintf('Handler "%s" is added by the factory.', $handler)
-             );
+            // PHPUNIT for PHP 5.6 has no getParameters() method.
+            $parameters = version_compare(PHP_VERSION, 7) < 0
+                ? $invocation->parameters
+                : $invocation->getParameters();
+            $handler = get_class($parameters[0]);
+            $this->assertContains(
+                $handler,
+                $expectedHandlers,
+                sprintf('Handler "%s" is added by the factory.', $handler)
+            );
         }
     }
 
@@ -79,19 +82,13 @@ class ChannelOpeningHoursHtmlTest extends TestCase
     {
         $collection = ChannelCollection::fromArray([]);
 
-        $client = $this
-            ->getMockBuilder(ClientInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(ClientInterface::class);
         $client
             ->expects($this->any())
             ->method('addHandler')
             ->will($this->returnValue($client));
 
-        $cache = $this
-            ->getMockBuilder(CacheInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $cache = $this->createMock(CacheInterface::class);
         $cache
             ->expects($this->once())
             ->method('get')

--- a/tests/ChannelOpeningHoursTest.php
+++ b/tests/ChannelOpeningHoursTest.php
@@ -15,6 +15,8 @@ use StadGent\Services\OpeningHours\Value\ChannelCollection;
  * Tests the ChannelOpeningHoursServiceFactory.
  *
  * @package StadGent\Services\Test\OpeningHours
+ *
+ * @covers \StadGent\Services\OpeningHours\ChannelOpeningHours
  */
 class ChannelOpeningHoursTest extends TestCase
 {
@@ -31,10 +33,7 @@ class ChannelOpeningHoursTest extends TestCase
         ];
 
         // Create the client so we can spy on the factory method.
-        $client = $this
-            ->getMockBuilder(ClientInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(ClientInterface::class);
 
         // Inject a spy so we can validate the injected handlers.
         $spy = $this->any();
@@ -63,12 +62,16 @@ class ChannelOpeningHoursTest extends TestCase
         // Validate the added handlers.
         $invocations = $spy->getInvocations();
         foreach ($invocations as $invocation) {
-             /** @noinspection PhpUndefinedFieldInspection */
-             $handler = get_class($invocation->parameters[0]);
-             $this->assertTrue(
-                 in_array($handler, $expectedHandlers, true),
-                 sprintf('Handler "%s" is added by the factory.', $handler)
-             );
+            // PHPUNIT for PHP 5.6 has no getParameters() method.
+            $parameters = version_compare(PHP_VERSION, 7) < 0
+                ? $invocation->parameters
+                : $invocation->getParameters();
+            $handler = get_class($parameters[0]);
+            $this->assertContains(
+                $handler,
+                $expectedHandlers,
+                sprintf('Handler "%s" is added by the factory.', $handler)
+            );
         }
     }
 
@@ -79,19 +82,13 @@ class ChannelOpeningHoursTest extends TestCase
     {
         $collection = ChannelCollection::fromArray([]);
 
-        $client = $this
-            ->getMockBuilder(ClientInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(ClientInterface::class);
         $client
             ->expects($this->any())
             ->method('addHandler')
             ->will($this->returnValue($client));
 
-        $cache = $this
-            ->getMockBuilder(CacheInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $cache = $this->createMock(CacheInterface::class);
         $cache
             ->expects($this->once())
             ->method('get')

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -15,6 +15,8 @@ use StadGent\Services\OpeningHours\Value\ChannelCollection;
  * Class RoomServiceFactoryTest
  *
  * @package Gent\Zalenzoeker\Tests\Services\Room
+ *
+ * @covers \StadGent\Services\OpeningHours\Channel
  */
 class ChannelTest extends TestCase
 {
@@ -31,10 +33,7 @@ class ChannelTest extends TestCase
         ];
 
         // Create the client so we can spy on the factory method.
-        $client = $this
-            ->getMockBuilder(ClientInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(ClientInterface::class);
 
         // Inject a spy so we can validate the injected handlers.
         $spy = $this->any();
@@ -63,12 +62,16 @@ class ChannelTest extends TestCase
         // Validate the added handlers.
         $invocations = $spy->getInvocations();
         foreach ($invocations as $invocation) {
-             /** @noinspection PhpUndefinedFieldInspection */
-             $handler = get_class($invocation->parameters[0]);
-             $this->assertTrue(
-                 in_array($handler, $expectedHandlers, true),
-                 sprintf('Handler "%s" is added by the factory.', $handler)
-             );
+            // PHPUNIT for PHP 5.6 has no getParameters() method.
+            $parameters = version_compare(PHP_VERSION, 7) < 0
+                ? $invocation->parameters
+                : $invocation->getParameters();
+            $handler = get_class($parameters[0]);
+            $this->assertContains(
+                $handler,
+                $expectedHandlers,
+                sprintf('Handler "%s" is added by the factory.', $handler)
+            );
         }
     }
 
@@ -79,19 +82,13 @@ class ChannelTest extends TestCase
     {
         $collection = ChannelCollection::fromArray([]);
 
-        $client = $this
-            ->getMockBuilder(ClientInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(ClientInterface::class);
         $client
             ->expects($this->any())
             ->method('addHandler')
             ->will($this->returnValue($client));
 
-        $cache = $this
-            ->getMockBuilder(CacheInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $cache = $this->createMock(CacheInterface::class);
         $cache
             ->expects($this->once())
             ->method('get')

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -17,6 +17,8 @@ use StadGent\Services\OpeningHours\Value\ServiceCollection;
  * Class RoomServiceFactoryTest
  *
  * @package Gent\Zalenzoeker\Tests\Services\Room
+ *
+ * @covers \StadGent\Services\OpeningHours\Service
  */
 class ServiceTest extends TestCase
 {
@@ -35,10 +37,7 @@ class ServiceTest extends TestCase
         ];
 
         // Create the client so we can spy on the factory method.
-        $client = $this
-            ->getMockBuilder(ClientInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(ClientInterface::class);
 
         // Inject a spy so we can validate the injected handlers.
         $spy = $this->any();
@@ -67,13 +66,16 @@ class ServiceTest extends TestCase
         // Validate the added handlers.
         $invocations = $spy->getInvocations();
         foreach ($invocations as $invocation) {
-             /** @noinspection PhpUndefinedFieldInspection */
-             $handler = get_class($invocation->parameters[0]);
-             $this->assertContains(
-                 $handler,
-                 $expectedHandlers,
-                 sprintf('Handler "%s" is added by the factory.', $handler)
-             );
+            // PHPUNIT for PHP 5.6 has no getParameters() method.
+            $parameters = version_compare(PHP_VERSION, 7) < 0
+                ? $invocation->parameters
+                : $invocation->getParameters();
+            $handler = get_class($parameters[0]);
+            $this->assertContains(
+                $handler,
+                $expectedHandlers,
+                sprintf('Handler "%s" is added by the factory.', $handler)
+            );
         }
     }
 


### PR DESCRIPTION
Updated the package so it supports also PHP 7.2

## Description

- Updated composer so it supports PHPUnit for PHP 5.6 & 7.
- Updated tests so they run in PHPUnit 6.

## How Has This Been Tested?

- [x] PHPUnit in PHP 5.6
- [x] PHPUnit in PHP 7.0
- [x] PHPUnit in PHP 7.1
- [x] PHPUnit in PHP 7.2

## Types of changes

- [x] New feature (non-breaking change which adds functionality).

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
