### PR TITLE
DMOH-45: Fixed failure in handler on empty response from OpenData platform

### DIFF
--- a/src/Handler/Service/GetByOpenDataUriHandler.php
+++ b/src/Handler/Service/GetByOpenDataUriHandler.php
@@ -33,7 +33,10 @@ class GetByOpenDataUriHandler extends HandlerAbstract
     public function toResponse(Psr\ResponseInterface $response)
     {
         $all = $this->getBodyData($response);
-        $data = reset($all);
+        $data = $all;
+        if (!empty($all)) {
+            $data = reset($all);
+        }
         $service = Service::fromArray($data);
         return new ServiceResponse($service);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a PHP exception when the OpenData response for a Vesta ID is empty.

## Motivation and Context

The PHP exception was nigh uncatchable.
DMOH-45

## How Has This Been Tested?

Openinghours import in Stad.gent D8 development.

## Screenshots (if appropriate):

<!--- Upload screenshots if appropriate. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
