### PR TITLE
TTWEBTAKEN-134: Fix endpoint key is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `gent/services-opening-hours` package.
 
+## [Unreleased]
+
+### Fixed
+
+- TTWEBTAKEN-134: Fix endpoint key is optional.
+
 ## [2.0.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ projects. Questions about our approach can be asked through the issue queue
 [ico-version-unstable]: https://img.shields.io/packagist/vpre/stadgent/services-opening-hours.svg
 [ico-downloads]: https://img.shields.io/packagist/dt/stadgent/services-opening-hours.svg
 [ico-license]: https://img.shields.io/github/license/StadGent/php_package_services-opening-hours.svg
-[ico-travis]: https://img.shields.io/travis/StadGent/php_package_services-opening-hours/master.svg
+[ico-travis]: https://app.travis-ci.com/StadGent/php_package_services-opening-hours.svg?branch=develop
 [ico-maintainability]: https://api.codeclimate.com/v1/badges/84475b0bcdae04464dd8/maintainability
 [ico-test-coverage]: https://api.codeclimate.com/v1/badges/84475b0bcdae04464dd8/test_coverage
 
 [link-packagist]: https://packagist.org/packages/stadgent/services-opening-hours
 [link-license]: LICENSE.md
-[link-travis]: https://travis-ci.org/StadGent/php_package_services-opening-hours
+[link-travis]: https://app.travis-ci.com/StadGent/php_package_services-opening-hours
 [link-maintainability]: https://codeclimate.com/github/StadGent/php_package_services-opening-hours/maintainability
 [link-test-coverage]: https://codeclimate.com/github/StadGent/php_package_services-opening-hours/test_coverage
 [link-author-stadgent]: https://github.com/stadgent

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -16,14 +16,14 @@ final class Configuration extends BaseConfiguration implements ConfigurationInte
     /**
      * The API key.
      *
-     * @var string
+     * @var string|null
      */
-    private string $key;
+    private ?string $key;
 
     /**
      * @inheritDoc
      */
-    public function __construct(string $endpointUri, string $key, array $options = [])
+    public function __construct(string $endpointUri, ?string $key = null, array $options = [])
     {
         parent::__construct($endpointUri, $options);
         $this->key = $key;
@@ -32,7 +32,7 @@ final class Configuration extends BaseConfiguration implements ConfigurationInte
     /**
      * @inheritDoc
      */
-    public function getKey(): string
+    public function getKey(): ?string
     {
         return $this->key;
     }

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -16,8 +16,8 @@ interface ConfigurationInterface extends BaseConfigurationInterface
     /**
      * Get the API key.
      *
-     * @return string
+     * @return string|null
      *   The API key.
      */
-    public function getKey(): string;
+    public function getKey(): ?string;
 }

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -13,16 +13,15 @@ use PHPUnit\Framework\TestCase;
 class ConfigurationTest extends TestCase
 {
     /**
-     * Test constructor without options.
+     * Test constructor without key.
      */
-    public function testConstructorWithoutOptions()
+    public function testConstructorWithoutKeyAndOptions()
     {
         $uri = 'https://test-endpoint.stad.gent';
-        $key = 'whatever-key';
-        $configuration = new Configuration($uri, $key);
+        $configuration = new Configuration($uri);
 
         $this->assertEquals($uri, $configuration->getUri(), 'Uri is set.');
-        $this->assertEquals($key, $configuration->getKey(), 'Key is set.');
+        $this->assertNull($configuration->getKey(), 'Key is by default null.');
 
         // Default options
         $this->assertEquals(
@@ -37,14 +36,16 @@ class ConfigurationTest extends TestCase
      */
     public function testConstructorWithOptions()
     {
+        $uri = 'https://test-endpoint.stad.gent';
+        $key = 'foo-bar';
         $options = [
             'timeout' => 10,
         ];
-        $configuration = new Configuration(
-            'https://foo.com',
-            'whatever-key',
-            $options
-        );
+
+        $configuration = new Configuration($uri, $key, $options);
+
+        $this->assertEquals($uri, $configuration->getUri(), 'Uri is set.');
+        $this->assertEquals($key, $configuration->getKey(), 'Key is set.');
 
         // Custom options
         $this->assertEquals(


### PR DESCRIPTION
The endpoint key is only required when accessing the Opening Hours
service through the services platform. Made the key optional to support
direct usage of the Opening Hours platform API.
