### PR TITLE
DMOH-58: Add load service by source id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `gent/services-opening-hours` package.
 
+## [Unreleased]
+
+### Added
+
+- DMOH-58: Add load service by source id.
+
 ## [2.0.1]
 
 ### Fixed

--- a/examples/106-Service-GetBySourceId.php
+++ b/examples/106-Service-GetBySourceId.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * StadGent\Services\OpeningHours Examples.
+ *
+ * Example how to get a single service by its Vesta ID.
+ *
+ * @var string $apiEndpoint
+ * @var string $apiKey
+ * @var string $service_source
+ * @var string $service_source_id
+ */
+
+use GuzzleHttp\Client as GuzzleClient;
+use StadGent\Services\OpeningHours\Configuration\Configuration;
+use StadGent\Services\OpeningHours\Client\Client;
+use StadGent\Services\OpeningHours\Service;
+
+require_once __DIR__ . '/bootstrap.php';
+
+example_print_header('Example how to get a single service by its source ID.');
+
+example_print_step('Create the API client configuration.');
+$configuration = new Configuration($apiEndpoint, $apiKey);
+
+example_print_step('Create the Guzzle client.');
+$guzzleClient = new GuzzleClient(['base_uri' => $configuration->getUri()]);
+
+example_print_step('Create the HTTP client.');
+$client = new Client($guzzleClient, $configuration);
+
+example_print_step('Get the ServiceService.');
+$service = Service::create($client);
+
+example_print_step('Search Services GetBySourceId');
+example_print();
+
+try {
+    $serviceItem = $service->getBySourceId($service_source, $service_source_id);
+    example_sprintf(' Id        : %d', $serviceItem->getId());
+    example_sprintf(' URI       : %s', $serviceItem->getUri());
+    example_sprintf(' Label     : %s', $serviceItem->getLabel());
+    example_sprintf(' Is Draft  : %d', (int) $serviceItem->isDraft());
+    example_sprintf(' Source    : %s', $serviceItem->getSource()->getName());
+    example_sprintf(' Source ID : %s', $serviceItem->getSource()->getId());
+} catch (\StadGent\Services\OpeningHours\Exception\ServiceNotFoundException $e) {
+    example_sprintf(' ! No Service found for source : %s:%s', $service_source, $service_source_id);
+} catch (\Exception $e) {
+    example_sprintf(' ! Error : %s', $e->getMessage());
+}
+
+example_print_footer();

--- a/examples/config.example.php
+++ b/examples/config.example.php
@@ -26,8 +26,9 @@ $service_uri = '';
 // Service to load by its Vesta ID.
 $service_vesta_id = '';
 
-
-
+// Service to load by its source ID
+$service_source = '';
+$service_source_id = '';
 
 
 // Channel Data to lookup data for --------------------------------------------
@@ -35,9 +36,6 @@ $service_vesta_id = '';
 // Channel to load by its id.
 // This id will also be used to lookup channel opening hours.
 $channel_id = '';
-
-
-
 
 
 // Dates to lookup OpeningHours for -------------------------------------------

--- a/src/Handler/Service/ExtractFirstHandler.php
+++ b/src/Handler/Service/ExtractFirstHandler.php
@@ -6,16 +6,18 @@ namespace StadGent\Services\OpeningHours\Handler\Service;
 
 use StadGent\Services\OpeningHours\Handler\HandlerAbstract;
 use StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest;
+use StadGent\Services\OpeningHours\Request\Service\GetBySourceIdRequest;
 use StadGent\Services\OpeningHours\Response\ServiceResponse;
 use StadGent\Services\OpeningHours\Value\Service;
 use Psr\Http\Message as Psr;
 
 /**
- * Handler to Get a Service by its open data URI.
+ * Handler to extract the first item from all services response.
  *
- * @package StadGent\Services\OpeningHours\Handler\Service
+ * Is used to extract all services responses where there is filtered by a single
+ * sourceId or Uri.
  */
-final class GetByOpenDataUriHandler extends HandlerAbstract
+final class ExtractFirstHandler extends HandlerAbstract
 {
     /**
      * @inheritDoc
@@ -24,6 +26,7 @@ final class GetByOpenDataUriHandler extends HandlerAbstract
     {
         return [
             GetByOpenDataUriRequest::class,
+            GetBySourceIdRequest::class,
         ];
     }
 

--- a/src/Request/Service/GetBySourceIdRequest.php
+++ b/src/Request/Service/GetBySourceIdRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StadGent\Services\OpeningHours\Request\Service;
+
+use DigipolisGent\API\Client\Request\AbstractJsonRequest;
+use StadGent\Services\OpeningHours\Uri\Service\GetBySourceIdUri;
+
+/**
+ * Request to get a Service by its source and source id.
+ *
+ * @package StadGent\Services\OpeningHours\Request\Service
+ */
+final class GetBySourceIdRequest extends AbstractJsonRequest
+{
+    /**
+     * Get a single Service by its open data URI.
+     *
+     * @param string $source
+     *   The source.
+     * @param string $sourceId
+     *   The source id.
+     */
+    public function __construct(string $source, string $sourceId)
+    {
+        $uri = new GetBySourceIdUri($source, $sourceId);
+        parent::__construct($uri);
+    }
+}

--- a/src/Service.php
+++ b/src/Service.php
@@ -7,8 +7,8 @@ namespace StadGent\Services\OpeningHours;
 use DigipolisGent\API\Client\ClientInterface;
 use Psr\SimpleCache\CacheInterface;
 use StadGent\Services\OpeningHours\Handler\Service\GetAllHandler;
+use StadGent\Services\OpeningHours\Handler\Service\ExtractFirstHandler;
 use StadGent\Services\OpeningHours\Handler\Service\GetByIdHandler;
-use StadGent\Services\OpeningHours\Handler\Service\GetByOpenDataUriHandler;
 use StadGent\Services\OpeningHours\Service\Service\ServiceService;
 use StadGent\Services\OpeningHours\Service\Service\ServiceServiceInterface;
 
@@ -34,7 +34,7 @@ final class Service
     {
         $client->addHandler(new GetAllHandler());
         $client->addHandler(new GetByIdHandler());
-        $client->addHandler(new GetByOpenDataUriHandler());
+        $client->addHandler(new ExtractFirstHandler());
 
         $service = new ServiceService($client);
         if ($cache) {

--- a/src/Service/Service/ServiceServiceInterface.php
+++ b/src/Service/Service/ServiceServiceInterface.php
@@ -84,4 +84,21 @@ interface ServiceServiceInterface extends ServiceInterface, LoggableInterface, C
      * @throws \StadGent\Services\OpeningHours\Exception\ServiceNotFoundException
      */
     public function getByVestaId(string $vestaId): Service;
+
+    /**
+     * Get a single Service by its source name & source id.
+     *
+     * @param string $source
+     *   The source name (eg. recreatex).
+     * @param string $sourceId
+     *   The source ID (eg. ReCreateX  record UUID).
+     *
+     * @return \StadGent\Services\OpeningHours\Value\Service
+     *
+     * @throws \Exception
+     * @throws \GuzzleHttp\Exception\RequestException
+     * @throws \StadGent\Services\OpeningHours\Exception\NotFoundException
+     * @throws \StadGent\Services\OpeningHours\Exception\ServiceNotFoundException
+     */
+    public function getBySourceId(string $source, string $sourceId): Service;
 }

--- a/src/Uri/Service/GetBySourceIdUri.php
+++ b/src/Uri/Service/GetBySourceIdUri.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StadGent\Services\OpeningHours\Uri\Service;
+
+use StadGent\Services\OpeningHours\Uri\BaseUri;
+
+/**
+ * Uri to get a single service by its source & source id.
+ *
+ * @package StadGent\Services\OpeningHours\Uri\Channel
+ */
+final class GetBySourceIdUri extends BaseUri
+{
+    /**
+     * Construct the URI.
+     *
+     * @param string $source
+     *   The source name (eg. recreatex).
+     * @param string $sourceId
+     *   The source id (eg. ReCreateX UUID).
+     */
+    public function __construct(string $source, string $sourceId)
+    {
+        $this->uri = sprintf('services?source=%s&sourceId=%s', $source, $sourceId);
+    }
+}

--- a/tests/Handler/Service/GetFirstHandlerTest.php
+++ b/tests/Handler/Service/GetFirstHandlerTest.php
@@ -1,38 +1,40 @@
 <?php
 
+declare(strict_types=1);
+
 namespace StadGent\Services\Test\OpeningHours\Handler\Service;
 
-use StadGent\Services\OpeningHours\Handler\Service\GetByOpenDataUriHandler;
+use StadGent\Services\OpeningHours\Handler\Service\ExtractFirstHandler;
 use StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest;
+use StadGent\Services\OpeningHours\Request\Service\GetBySourceIdRequest;
 use StadGent\Services\OpeningHours\Response\ServiceResponse;
 use StadGent\Services\Test\OpeningHours\Handler\HandlerTestBase;
 
 /**
- * Test the GetByIdHandler.
- *
- * @package StadGent\Services\Test\OpeningHours\Handler\Service
- *
- * @covers StadGent\Services\OpeningHours\Handler\Service\GetByOpenDataUriHandler
+ * @covers \StadGent\Services\OpeningHours\Handler\Service\ExtractFirstHandler
  */
-class GetByOpenDataUriHandlerTest extends HandlerTestBase
+final class GetFirstHandlerTest extends HandlerTestBase
 {
     /**
      * Test the handles method.
      */
-    public function testHandles()
+    public function testHandles(): void
     {
-        $handler = new GetByOpenDataUriHandler();
+        $handler = new ExtractFirstHandler();
         $this->assertEquals(
-            [GetByOpenDataUriRequest::class],
+            [
+                GetByOpenDataUriRequest::class,
+                GetBySourceIdRequest::class,
+            ],
             $handler->handles(),
-            'Handler only handles \StadGent\Services\OpeningHours\Request\Service\GetByOpenDataUriRequest.'
+            'Handles GetByOpenDataUriRequest & GetBySourceIdRequest.'
         );
     }
 
     /**
      * Test the toResponse method with returned data.
      */
-    public function testToResponseWithData()
+    public function testToResponseWithData(): void
     {
         $body = <<<EOT
     [
@@ -52,7 +54,7 @@ class GetByOpenDataUriHandlerTest extends HandlerTestBase
 EOT;
         $serviceResponse = $this->createResponseMock(200, $body);
 
-        $handler = new GetByOpenDataUriHandler();
+        $handler = new ExtractFirstHandler();
         $response = $handler->toResponse($serviceResponse);
 
         $this->assertInstanceOf(

--- a/tests/Request/Service/GetBySourceIdRequestTest.php
+++ b/tests/Request/Service/GetBySourceIdRequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StadGent\Services\Test\OpeningHours\Request\Service;
+
+use DigipolisGent\API\Client\Request\AcceptType;
+use DigipolisGent\API\Client\Request\MethodType;
+use PHPUnit\Framework\TestCase;
+use StadGent\Services\OpeningHours\Request\Service\GetBySourceIdRequest;
+
+/**
+ * @covers \StadGent\Services\OpeningHours\Request\Service\GetBySourceIdRequest
+ *
+ * @package StadGent\Services\Test\OpeningHours\Request\Service
+ */
+final class GetBySourceIdRequestTest extends TestCase
+{
+    /**
+     * The request uses GET method.
+     *
+     * @test
+     */
+    public function itHasGetMethod(): void
+    {
+        $request = new GetBySourceIdRequest('source_name', 'source_id');
+        $this->assertEquals(MethodType::GET, $request->getMethod());
+    }
+
+    /**
+     * The endpoint includes the proper GET parameters
+     *
+     * @test
+     */
+    public function itHasProperGetParameter(): void
+    {
+        $request = new GetBySourceIdRequest('source_name', 'source_id');
+        $this->assertEquals('services?source=source_name&sourceId=source_id', $request->getRequestTarget());
+    }
+
+    /**
+     * We only accept JSON responses.
+     */
+    public function itHasJsonAcceptType(): void
+    {
+        $request = new GetBySourceIdRequest('source_name', 'source_id');
+        $this->assertEquals(AcceptType::JSON, $request->getHeaderLine('Accept'));
+    }
+}

--- a/tests/Service/Service/ServiceServiceGetBySourceIdTest.php
+++ b/tests/Service/Service/ServiceServiceGetBySourceIdTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StadGent\Services\Test\OpeningHours\Service\Service;
+
+use StadGent\Services\OpeningHours\Exception\ServiceNotFoundException;
+use StadGent\Services\OpeningHours\Request\Service\GetBySourceIdRequest;
+use StadGent\Services\OpeningHours\Response\ServiceResponse;
+use StadGent\Services\OpeningHours\Service\Service\ServiceService;
+use StadGent\Services\OpeningHours\Value\Service;
+use StadGent\Services\Test\OpeningHours\Service\ServiceTestBase;
+
+/**
+ * Tests for ServiceService::getBySourceId Method.
+ *
+ * @covers \StadGent\Services\OpeningHours\Service\Service\ServiceService
+ */
+final class ServiceServiceGetBySourceIdTest extends ServiceTestBase
+{
+    /**
+     * Loaded from service when not in cache.
+     *
+     * @test
+     */
+    public function itLoadsFromServiceWhenNotInCache(): void
+    {
+        $service = $this->createService();
+        $client = $this->createClientForService($service);
+
+        $serviceService = new ServiceService($client);
+        $responseService = $serviceService->getBySourceId('source_name', 'source_id');
+        $this->assertSame($service, $responseService);
+    }
+
+    /**
+     * Loaded from cache when available.
+     *
+     * @test
+     */
+    public function itReturnsServiceFromCacheWhenAvailable(): void
+    {
+        $service = $this->createService();
+        $client = $this->createClientForService($service);
+        $cache = $this->getFromCacheMock('OpeningHours:service:value:sourceId:source_name:source_id', $service);
+
+        $serviceService = new ServiceService($client);
+        $serviceService->setCacheService($cache);
+        $responseService = $serviceService->getBySourceId('source_name', 'source_id');
+        $this->assertSame($service, $responseService);
+    }
+
+    /**
+     * The item is stored in cache when loaded from service.
+     *
+     * @test
+     */
+    public function itCachesLoadedService(): void
+    {
+        $service = $this->createService();
+        $client = $this->createClientForService($service);
+        $cache = $this->getSetCacheMock('OpeningHours:service:value:sourceId:source_name:source_id', $service);
+
+        $serviceService = new ServiceService($client);
+        $serviceService->setCacheService($cache);
+        $serviceService->getBySourceId('source_name', 'source_id');
+    }
+
+    /**
+     * Exception is thrown when no item could be found by the source id.
+     *
+     * @test
+     */
+    public function itThrowsNotFoundException(): void
+    {
+        $this->expectException(ServiceNotFoundException::class);
+        $client = $this->getClientWithServiceNotFoundExceptionMock();
+        $serviceService = new ServiceService($client);
+        $serviceService->getBySourceId('source_name', 'source_id');
+    }
+
+    /**
+     * Helper to create a service.
+     *
+     * @return \StadGent\Services\OpeningHours\Value\Service
+     */
+    protected function createService()
+    {
+        return Service::fromArray(
+            [
+                'id' => 10,
+                'uri' => 'http://foo.bar/123',
+                'label' => 'FizzBazz label',
+                'createdAt' => '2345-11-05T12:45:00+01:00',
+                'updatedAt' => '2345-11-12T14:12:11+01:00',
+            ]
+        );
+    }
+
+    /**
+     * Helper to create a client that will return the given service.
+     *
+     * @param \StadGent\Services\OpeningHours\Value\Service $service
+     *
+     * @return \DigipolisGent\API\Client\ClientInterface
+     */
+    protected function createClientForService(Service $service)
+    {
+        $response = new ServiceResponse($service);
+        $expectedRequest = GetBySourceIdRequest::class;
+        return $this->getClientMock($response, $expectedRequest);
+    }
+}

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -7,7 +7,7 @@ use Psr\SimpleCache\CacheInterface;
 use DigipolisGent\API\Client\ClientInterface;
 use StadGent\Services\OpeningHours\Handler\Service\GetAllHandler;
 use StadGent\Services\OpeningHours\Handler\Service\GetByIdHandler;
-use StadGent\Services\OpeningHours\Handler\Service\GetByOpenDataUriHandler;
+use StadGent\Services\OpeningHours\Handler\Service\ExtractFirstHandler;
 use StadGent\Services\OpeningHours\Handler\Service\SearchByLabelHandler;
 use StadGent\Services\OpeningHours\Service;
 use StadGent\Services\OpeningHours\Service\Service\ServiceService;
@@ -31,7 +31,7 @@ class ServiceTest extends TestCase
         $expectedHandlers = [
             GetAllHandler::class,
             GetByIdHandler::class,
-            GetByOpenDataUriHandler::class
+            ExtractFirstHandler::class
         ];
 
         // Create the client so we can spy on the factory method.

--- a/tests/Uri/Service/GetBySourceIdUriTest.php
+++ b/tests/Uri/Service/GetBySourceIdUriTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StadGent\Services\Test\OpeningHours\Uri\Service;
+
+use PHPUnit\Framework\TestCase;
+use StadGent\Services\OpeningHours\Uri\Service\GetBySourceIdUri;
+
+/**
+ * @covers \StadGent\Services\OpeningHours\Uri\Service\GetBySourceIdUri
+ *
+ * @package StadGent\Services\Test\OpeningHours
+ */
+final class GetBySourceIdUriTest extends TestCase
+{
+    /**
+     * The URI should contain the source and source id values.
+     *
+     * @test
+     */
+    public function testConstruct(): void
+    {
+        $uri = new GetBySourceIdUri('source_name', 'source_id');
+
+        $expected = 'services?source=source_name&sourceId=source_id';
+        $this->assertEquals($expected, $uri->getUri());
+    }
+}


### PR DESCRIPTION
The method to get all services can be filtered by source (eg. recreatex) and sourceId (eg. ReCreateX UUID).

Added service class method to load a single service by its source and sourceId.

## Description

- Added URI, Request and service class method to get a single Service by its source name and source id.
- Refactored the handler to extract first result from all services request.
